### PR TITLE
Add cli path option

### DIFF
--- a/universions/cli.py
+++ b/universions/cli.py
@@ -1,6 +1,7 @@
 """Main file to call universions from the CLI."""
 
 import argparse
+from pathlib import Path
 
 from universions.git import get_git_version
 from universions.java import get_java_version
@@ -109,7 +110,12 @@ def main() -> int:
         parser.print_help()
         return 0
     get_version = TOOLS.get(tool_name)
-    version = get_version(args.path)
+    if args.path is not None:
+        tool_path = Path(args.path)
+        version = get_version(tool_path)
+    else:
+        version = get_version()
+
     print(print_version(version, args.verbosity))
 
     return 0

--- a/universions/cli.py
+++ b/universions/cli.py
@@ -35,11 +35,15 @@ TOOLS = {
 def get_args_parser():
     """Get the arguments parser of the program."""
     parser = argparse.ArgumentParser()
-    parser.add_argument(
+    tool_group = parser.add_argument_group()
+    tool_group.add_argument(
         "tool",
         help="select the tool whose version is wanted",
         nargs="?",
         choices=list(TOOLS.keys()),
+    )
+    tool_group.add_argument(
+        "-p", "--path", help="Sets the path to the tool to inspect", default=None
     )
     parser.add_argument(
         "-a", "--all", action="store_true", help="display all the tools version"
@@ -105,7 +109,7 @@ def main() -> int:
         parser.print_help()
         return 0
     get_version = TOOLS.get(tool_name)
-    version = get_version()
+    version = get_version(args.path)
     print(print_version(version, args.verbosity))
 
     return 0


### PR DESCRIPTION
Option added and I created a special option group for it. Supposedly it should prevent the `--path` option to be used with other options.
Writing a test is challenging. SImply passing the argument to an existing binary would return the same result as the actual call without a path.
If you want, I can create a script returning a fake version for npm and call it.