### PR TITLE
Fix the comparaison, pre < stable and None does not fail.

### DIFF
--- a/test/test_comparaison.py
+++ b/test/test_comparaison.py
@@ -1,0 +1,65 @@
+"""Test comparaison between versions."""
+
+from universions import Version
+
+
+def test_compare_version_to_tuple():
+    """Compare a simple version to other numbers."""
+    version = Version(2, 1)
+
+    # EQ
+    assert version == (2, 1)
+    assert version == (2, 1, None)
+    assert version == Version(2, 1)
+
+    # LT
+    assert version < (2, 2)
+    assert version < (3, 0)
+    assert version < (2, 1, 0)
+    assert version < (3,)
+
+    #  LTE
+    assert version <= (2, 2)
+    assert version <= (3, 0)
+    assert version <= (2, 1)
+    assert version <= (2, 1, 0)
+
+    # GT
+    assert version > (0, 1)
+    assert version > (2, 0)
+    assert version > (2,)
+
+    # GTE
+    assert version >= (0, 1)
+    assert version >= (2, 0)
+    assert version >= (2,)
+    assert version >= (2, 1)
+
+    # NE
+    assert version != (2, 2)
+
+
+def test_compare_partial():
+    """Compare partial version numbers."""
+    assert Version(1, 0) > Version(1)
+    assert Version(1, 0, 0) > Version(1, 0)
+
+
+def test_compare_prerelease():
+    """Pre-release have a lower precedence than the associated normal version."""
+    # https://semver.org/#spec-item-9
+    assert Version(1, 0, 0) > Version(1, 0, 0, "beta")
+    assert Version(1, 0, 0) > (1, 0, 0, "beta")
+    assert Version(1, 0) > Version(1, 0, prerelease="beta")
+    assert Version(1, 0) > (1, 0, None, "beta")
+
+    assert Version(1, 0, 0, "beta") > Version(1, 0, 0, "alpha")
+    assert Version(1, 0, 0, "alpha") < Version(1, 0, 0, "beta")
+    assert Version(1, 0, 0, "alpha") == (1, 0, 0, "alpha")
+
+
+def test_compare_build():
+    """Build version must not be use in precedence."""
+    # https://semver.org/#spec-item-10
+    assert Version(1, 0, 0, None, "build1") == Version(1, 0, 0)
+    assert Version(1, 0, 0, None, "build1") == Version(1, 0, 0, None, "build2")

--- a/test/test_version_type.py
+++ b/test/test_version_type.py
@@ -37,14 +37,3 @@ def test_full_version():
     assert version.patch == 0
     assert version.prerelease == "rc.5"
     assert version.build == "eg5f6d"
-
-
-def test_compare_version_with_major_minor():
-    version = Version(1, 0)
-    assert version > (0, 1)
-    assert version < (1, 1)
-    #  assert version == (1, 0)
-    assert version != (1, 0, 0)
-    assert version < (2,)
-    assert version > (0,)
-    assert version > (0, 1, 10, "rc2", "build-455")


### PR DESCRIPTION
Not the prettiest code but it fixes #59 


- Pre-release versions have a lower precedence than the associated normal version : [semver 9](https://semver.org/#spec-item-9)
- Build metadata MUST be ignored when determining version precedence : [semver 10](https://semver.org/#spec-item-10)
- Can compare with None or smaller version.