### PR TITLE
Correct the parsing of Java version.

### DIFF
--- a/test/test_java_version.py
+++ b/test/test_java_version.py
@@ -63,7 +63,7 @@ JAVA_14_PRE = (
 
 JAVA_PARAMETERS = [
     pytest.param(JAVA_5, "1.5.0_29", Version(1, 5, 29)),
-    pytest.param(JAVA_6, "1.6.0-119", Version(1, 6, 0, "119")),  # wrong parsing here
+    pytest.param(JAVA_6, "1.6.0_119", Version(1, 6, 119)),  # wrong parsing here
     pytest.param(JAVA_7, "1.7.0_55", Version(1, 7, 55)),
     pytest.param(JAVA_8, "1.8.0_151", Version(1, 8, 151)),
     pytest.param(JAVA_11, "11.0.5", Version(11, 0, 5)),

--- a/universions/java/__init__.py
+++ b/universions/java/__init__.py
@@ -117,4 +117,5 @@ def _parse_version_string(cmd_result: str) -> str:
         line for line in split_lines if len(line) > 0 and line[1] == "version"
     ][0]
     version_string = version_line[2].replace('"', "")
+    version_string = re.sub(r"-(\d)", r"_\1", version_string)
     return version_string


### PR DESCRIPTION
A little trick to fix old version numbers using a "-" instead of "_".
It fixes #2.